### PR TITLE
Release v3.1.3

### DIFF
--- a/batMan/CHANGELOG.md
+++ b/batMan/CHANGELOG.md
@@ -1,5 +1,9 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+### 3.1.3
+
+- Fix mcp handle code. It forced it to 0 if present in the schedule.
+
 ### 3.1.1
 
 - Fix code

--- a/batMan/config.yaml
+++ b/batMan/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: Battery manager
-version: "3.1.2"
+version: "3.1.3"
 slug: batman
 description: Manage your home batteries.
 url: "https://github.com/Local901/battery-management/"

--- a/batMan/rootfs/src/config.py
+++ b/batMan/rootfs/src/config.py
@@ -76,9 +76,9 @@ class Config:
                         result["action"] = Action(-int(split[index + 1]))
                         index += 1
                     case "mcp":
-                        result["minimumChargePercentage"] = min(
+                        result["minimumChargePercentage"] = max(
                             0,
-                            max(
+                            min(
                                 int(split[index + 1]),
                                 100
                             )


### PR DESCRIPTION
Fix `mcp` schedule action.

If set it would be forced to 0 negating the configured minimum charge percentage